### PR TITLE
Revisar configuració CORS

### DIFF
--- a/src/main/java/com/debateia/config/CorsConfig.java
+++ b/src/main/java/com/debateia/config/CorsConfig.java
@@ -6,13 +6,13 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
-    
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-            .allowedOrigins("http://localhost:80", "http://localhost")
-            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-            .allowedHeaders("*")
-            .allowCredentials(true);
+                .allowedOrigins("http://localhost:80", "http://localhost", "http://localhost:8081")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
     }
 }

--- a/src/main/java/com/debateia/config/CorsConfig.java
+++ b/src/main/java/com/debateia/config/CorsConfig.java
@@ -10,7 +10,7 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-            .allowedOrigins("http://localhost:5173") // TODO: make sure what websites to accept, in worse case, accept all
+            .allowedOrigins("http://localhost:80", "http://localhost")
             .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
             .allowedHeaders("*")
             .allowCredentials(true);

--- a/src/main/java/com/debateia/config/SecurityConfig.java
+++ b/src/main/java/com/debateia/config/SecurityConfig.java
@@ -35,12 +35,12 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(final HttpSecurity http) throws Exception {
         http
-            .cors(cors -> cors.configurationSource(corsConfigurationSource())) // Add this line
-            .csrf(AbstractHttpConfigurer::disable)
-            .authorizeHttpRequests(req -> req.requestMatchers("/auth/**")
-                    .permitAll()
-                    .anyRequest()
-                    .authenticated())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource())) // Add this line
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(req -> req.requestMatchers("/auth/**")
+                        .permitAll()
+                        .anyRequest()
+                        .authenticated())
                 .sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
                 .authenticationProvider(authenticationProvider)
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
@@ -55,7 +55,8 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:80", "http://localhost"));
+        configuration
+                .setAllowedOrigins(Arrays.asList("http://localhost:80", "http://localhost", "http://localhost:8081"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setAllowCredentials(true);
@@ -64,7 +65,7 @@ public class SecurityConfig {
         source.registerCorsConfiguration("/**", configuration);
         return source;
     }
-    
+
     private void logout(
             final HttpServletRequest request, final HttpServletResponse response,
             final Authentication authentication) {

--- a/src/main/java/com/debateia/config/SecurityConfig.java
+++ b/src/main/java/com/debateia/config/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:5173"));
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:80", "http://localhost"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("*"));
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
Hemos actualizado el puerto permitido para las peticiones al backend. Como el frontend y el backend pertenecen a grupos distintos, inicialmente el backend solo aceptaba peticiones provenientes del puerto 5173. Sin embargo, el frontend se despliega en el puerto 80, por lo que se ha ajustado la configuración para permitir este puerto. El resto de la configuración de CORS es correcta.